### PR TITLE
Update submit-a-pull-request task description to use zulip/zulip-gci

### DIFF
--- a/tasks/submit-a-pull-request.md
+++ b/tasks/submit-a-pull-request.md
@@ -1,4 +1,4 @@
-# Submit A Pull Request to GCI Submissions Repository
+# Submit A Pull Request to Zulip GCI Repository
 
 This task is for getting you familiarize with the GitHub flow. 
 If you are already familiar with making a pull request in GitHub feel
@@ -13,7 +13,7 @@ to learn Git.
 
 ## Task
 
-* Fork the [gci-submissions](https://github.com/zulip/gci-submissions) repository.
+* Fork the [zulip-gci](https://github.com/zulip/zulip-gci) repository.
 If you are not sure what `fork` means refer to [this tutorial](https://guides.github.com/activities/forking/#fork).
 
 * Create a new branch called `submit-a-pull-request` in the forked repository.
@@ -38,5 +38,5 @@ if you are not sure what commit means.
 
 * Now commit the changes you just made as `Add Github handle to hello-world.md.`
 
-* Now go ahead and make Pull Request to gci-submissions. Refer to [this tutorial](https://guides.github.com/activities/hello-world/#pr)
+* Now go ahead and make Pull Request to zulip-gci. Refer to [this tutorial](https://guides.github.com/activities/hello-world/#pr)
 if you don't know how to make a pull request.

--- a/tasks/submit-a-pull-request.md
+++ b/tasks/submit-a-pull-request.md
@@ -19,7 +19,7 @@ If you are not sure what `fork` means refer to [this tutorial](https://guides.gi
 * Create a new branch called `submit-a-pull-request` in the forked repository.
 If you are not sure what a branch is refer to [this tutorial](https://guides.github.com/activities/hello-world/#branch).
 
-* Make a new folder `gci/submit-a-pull-request/`**`username`** where **username** is your GitHub username.
+* Make a new folder `submit-a-pull-request/`**`username`** where **username** is your GitHub username.
 
 * Create a new file called `hello-world.md` with the following content. Don't replace the username with 
 your GitHub username for now.


### PR DESCRIPTION
The submit-a-pull-request task was written before we removed the gci-submissions repo concept. The task now involves creating PRs in this repository instead. 

This PR updates the task description changing references to zulip/gci-submissions to zulip/zulip-gci and removes the gci/ prefix from folders created in task PRs