### PR TITLE
Update eslint task description

### DIFF
--- a/tasks/eslint.md
+++ b/tasks/eslint.md
@@ -37,11 +37,20 @@ in `.eslintrc.json`.
 Let `rule` be the rule in the task description on
 [codein.withgoogle.com](codein.withgoogle.com).
 
-1. Edit `.eslintrc.json` to switch the rule from 0 (off) or 1 (warning) to 2 (error)
-   or the value specified in the task description, e.g:
+1. Edit `.eslintrc.json` to switch the rule from 0 (off) or 1 (warning)
+   to the value specified in the task description. For example, in the 
+   case of the rule `no-alert`, the value specified is `2`, so the changed
+   rule looks like:
+
    ```
-   "no-alert": 2,  // Changes value 2 (error).
-   "comma-dangle": ["error", {  // Changes value to the rule specified in the description.
+   "no-alert": 2
+   ```
+
+   In the case of `comma-dangle`, changing the rule to the value specified
+   means the rule will now look like:
+
+   ```
+   "comma-dangle": ["error", {
      "arrays": "always-multiline",
      "objects": "always-multiline",
      "imports": "always-multiline",
@@ -53,13 +62,14 @@ Let `rule` be the rule in the task description on
 3. Fix the errors. You can either do this by hand, write a script, or use `eslint`'s
    [--fix](http://eslint.org/docs/user-guide/command-line-interface#fix) option
    or some combination.  If you do use `--fix`, you still need to review
-   the code manually to confirm that the changes look correct!
-4. Run tools/test-all, and make sure your code (still) passes all the tests.
+   the code manually to confirm that the changes look correct! Follow 
+   [these instructions](#using-eslint---fix) to use `--fix`.
+4. Run `tools/test-all`, and make sure your code (still) passes all the tests.
 5. Add a commit with message 'eslint: change `rule` from warning to
    error and fix violations' (where a value is specified, use that
-   instead of error, and if the current value is 0 or off, mention
+   instead of error, and if the current value is `0` or `off`, mention
    that).
-6. Submit a pull request to the zulip/zulip repository using the commit
+6. Submit a pull request to the `zulip/zulip` repository using the commit
    message as the title. Include a link to the pull request when you submit
    your task on the GCI website.
 
@@ -74,23 +84,22 @@ _Completion criteria_:
 
 ## Rules that need fixing
 All of the rules below have an associated GCI task.
-Unless otherwise mentioned, the task is to change the value from 0 or 1 to 2.
 This list is in order of number of errors.
 Where possible, a link to the explanation from the airbnb rules docs page is provided.
-Some of these rules may be fixed using `node npm_modules/.bin/eslint --fix`
-(after changing the value in `eslintrc.json` appropriately)
+If the rule has `(--fix)` next to it, it can be fixed using eslint's --fix option.
+Follow [these instructions](#using-eslint---fix) to do so.
 
-- [x] [no-loop-func](http://eslint.org/docs/rules/no-loop-func) (1 error)
+- [x] [no-loop-func](http://eslint.org/docs/rules/no-loop-func) (1 error) to be changed to `2`
       ([airbnb](http://eslint.org/docs/rules/valid-typeof))
       ([example pull request](https://github.com/zulip/zulip/pull/2408))
 - [ ] [new-cap](http://eslint.org/docs/rules/new-cap) (1 error) to be changed
       to `"new-cap": ["error", { "newIsCap": true, "capIsNew": false }]`
       ([airbnb](https://github.com/airbnb/javascript#naming--PascalCase))
-- [ ] [no-empty](http://eslint.org/docs/rules/no-empty) (2 errors)
-- [ ] [yoda](http://eslint.org/docs/rules/yoda) (3 errors) (--fix)
+- [ ] [no-empty](http://eslint.org/docs/rules/no-empty) (2 errors) to be changed to `2`
+- [ ] [yoda](http://eslint.org/docs/rules/yoda) (3 errors) (--fix) to be changed to `2`
 - [ ] [space-before-blocks](http://eslint.org/docs/rules/space-before-blocks) (2 errors) (--fix)
       ([airbnb 1](https://github.com/airbnb/javascript#whitespace--before-blocks),
-      [2](https://github.com/airbnb/javascript#functions--signature-spacing))
+      [2](https://github.com/airbnb/javascript#functions--signature-spacing)) to be changed to `2`
 - [ ] [brace-style](http://eslint.org/docs/rules/brace-style) (7 errors) (--fix)
       to be changed to `["error", "1tbs", { "allowSingleLine": true }]`
       ([airbnb](https://github.com/airbnb/javascript#blocks--cuddled-elses))
@@ -108,13 +117,12 @@ Some of these rules may be fixed using `node npm_modules/.bin/eslint --fix`
           }
         }],
     ```
-
-- [ ] [one-var](http://eslint.org/docs/rules/one-var) (32 errors) to be changed to `["error", "never"]`
-- [ ] [no-else-return](http://eslint.org/docs/rules/no-else-return) (39 errors)
-- [ ] [no-plusplus](http://eslint.org/docs/rules/no-plusplus) (40 errors)
+- [ ] [one-var](http://eslint.org/docs/rules/one-var) (32 errors) to be changed to `['error', 'never']`
+- [ ] [no-else-return](http://eslint.org/docs/rules/no-else-return) (39 errors) to be changed to `2`
+- [ ] [no-plusplus](http://eslint.org/docs/rules/no-plusplus) (40 errors) to be changed to `2`
       ([airbnb](https://github.com/airbnb/javascript#variables--unary-increment-decrement))
-- [ ] [no-shadow](http://eslint.org/docs/rules/no-shadow) (56 errors)
-- [ ] [max-len](http://eslint.org/docs/rules/max-len) (78 errors)
+- [ ] [no-shadow](http://eslint.org/docs/rules/no-shadow) (56 errors) to be changed to `2`
+- [ ] [max-len](http://eslint.org/docs/rules/max-len) (78 errors) to be changed to `2`
       ([airbnb](https://github.com/airbnb/javascript#whitespace--max-len)) to be changed to
 
     ```
@@ -145,10 +153,8 @@ Some of these rules may be fixed using `node npm_modules/.bin/eslint --fix`
         }],
     ```
 
-    Note that this will require removing the `jslint` linter, since
-    that enforces comma-dangle.  Note also that there's an `eslint
-    --fix` command that will do this automatically; you shouldn't
-    change all 800 of these manually.
+    Note that there's an `eslint --fix` command that will do this automatically;
+    you shouldn't change all 800 of these manually.
 
 
 ## Rules that need not be changed
@@ -164,3 +170,19 @@ The rules below do not have an associated GCI task.
    is `["error", "single", { "avoidEscape": true }]`
 5. [no-underscore-dangle](http://eslint.org/docs/rules/no-underscore-dangle) (410 errors)
       ([airbnb](https://github.com/airbnb/javascript#naming--leading-underscore))
+
+## Using eslint --fix
+Some of the rules can be fixed with eslint's 
+[--fix](http://eslint.org/docs/user-guide/command-line-interface#fix) option. 
+However, we would like to change just one rule per PR. Doing this involves a few steps,
+since `--fix` seems to fix all warnings as well as errors. 
+One way to work around this is to do the following:
+
+1. Change the rule that you are fixing to the specified value.
+2. `git add .eslintrc.json && git commit` with an appropriate commit message.
+3. Run `tools/lint-all` to see which files need changing.
+4. Change all warnings (`1`) to `0` (ignore).
+5. Run `eslint --fix static/js frontend_tests`. Note: If there are files in other directories, 
+   add them here.
+6. Run `git checkout .eslintrc.json`.
+7. Run `git add . && git commit` with a commit message explaining the fixes.


### PR DESCRIPTION
This PR adds the following:
1. Specify all rule values explicitly
2. Add instructions to use eslint --fix

Explicitly specifying all desired rule values will hopefully reduce ambiguity for both students and mentors reviewing the code.

The eslint --fix option is helpful, but in our case of fixing one rule at a time it involves a few steps. This PR adds instructions to do this.