### PR TITLE
review-slack-integrations: fix high

### DIFF
--- a/scripts/review-slack-integrations.py
+++ b/scripts/review-slack-integrations.py
@@ -16,7 +16,7 @@ For this task, review rows **%s** through **%s** in the spreadsheet.
 
 for n in range(5, 806, 30):
     low = n
-    high = max(n + 29, 806)
+    high = min(n + 29, 806)
     upload_task(
         # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
         name = 'Analyze Slack integrations: rows {} to {}'.format(low, high),


### PR DESCRIPTION
Currently the tasks are displaying all a high of 806 like this ![screenshot](https://cloud.githubusercontent.com/assets/9834624/20913200/d3034c78-bb43-11e6-8878-66f907de78a5.png)
