### PR TITLE
remotedev: Update base image id.

### DIFF
--- a/remotedev/create.py
+++ b/remotedev/create.py
@@ -172,7 +172,7 @@ See [Developing remotely](http://zulip.readthedocs.io/en/latest/dev-remote.html)
 
 if __name__ == '__main__':
     # define id of image to create new droplets from
-    template_id = "21193944"
+    template_id = "21444215"
 
     # get command line arguments
     args = parser.parse_args()


### PR DESCRIPTION
Updated base droplet for remote dev. 

Changes:
- `libgroonga0` has been updated which prevents pgroonga errors when running `tools/provision.py`.
- zulip/zulip upstream updated to a119719.
- Include nano syntax files via ~/.nanorc for zulipdev user.