### PR TITLE
translations: Fix commit tense typo.

### DIFF
--- a/tasks/translations.md
+++ b/tasks/translations.md
@@ -161,10 +161,10 @@ your benchmark. Make sure your improvement includes:
 sure to talk about it.
 
 * Create a commit with the improvements, with commit message `translations:
-Improving the <language> style guide.`
+Improve the <language> style guide.`
 
 * Create a pull request in the `zulip/zulip` repository, with title `translations:
- Improving the <language> style guide.`
+ Improve the <language> style guide.`
 
 *Completion criteria*: The mentors will verify that you have improved the style
 guide and put the translated terms in the appropriate sections, providing


### PR DESCRIPTION
As [stated](http://zulip.readthedocs.io/en/latest/version-control.html#commit-messages) in the docs, commit messages should be written in imperative tense.