### PR TITLE
request-remote-dev: note completion of steps 1 and 2

### DIFF
--- a/request-remote-dev.md
+++ b/request-remote-dev.md
@@ -40,7 +40,8 @@ If you haven't already, create an account on https://chat.zulip.org/.
 
 Next, join the **development help** stream. Create a new **stream message**
 with your GitHub username as the **topic** and request your remote dev
-instance. A core developer should reply letting you know they're working on
+instance. Please note that you've already done steps 1 and 2. A
+core developer should reply letting you know they're working on
 creating it as soon as they are available to help (they'll be using
 the tool in `remotedev/create.py` in this repository).
 


### PR DESCRIPTION
Typically, people request a dev instance, and then a core dev will ask them whether they've completed steps 1&2 already. Save a round trip by having new contributors report that they've already done those steps when making the request.