### PR TITLE
Move and update initial task scripts.

### DIFF
--- a/scripts/2017/translations.py
+++ b/scripts/2017/translations.py
@@ -1,0 +1,142 @@
+import argparse
+from upload import upload_task
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--force', dest='force', action="store_true", default=False)
+args = parser.parse_args()
+
+# Add customized task for Japanese and Korean, as these are mostly fully translated,
+# but have no style guides.
+languages_tasks = [
+    ('Arabic', ['A', 'B',]),
+    ('French', ['D',]),
+    ('Hungarian', ['A', 'B', 'C',]),
+    ('Italian', ['A', 'B', 'C',]),
+    ('Malayalam', ['A', 'B', 'C',]),
+    ('Polish', ['A', 'D',]),
+    ('Portuguese', ['B', 'C',]),
+    ('Russian', ['A', 'D']),
+    ('Serbian', ['A', 'B', 'C',]),
+    ('Turkish', ['A', 'B', 'C',]),
+]
+
+description = """Help translate Zulip into another language!
+
+Instructions for translations tasks are at
+https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md
+
+"""
+
+description_ABCD = description + "For this task, do **Task Type %(type)s** for " + \
+                  "**%(language)s**"
+description_E = description + """If you are a native speaker of a language that
+does not have a style guide yet and there is no translation task for it, feel
+free to propose a language for translation tasks!
+
+Before you claim this task, ask on Zulip `GCI tasks` stream to check that an
+appropriate task does not already exist.
+
+Once you get confirmation, claim the task and do **Task Type E**.
+"""
+
+for language_tasks in languages_tasks:
+    language = language_tasks[0]
+    tasks = language_tasks[1]
+    if 'A' in tasks:
+        upload_task(
+            # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+            name = '%s: Research web application translations' % (language),
+            description = description_ABCD % {'type': 'A', 'language': language},
+            status = 2, # 1: draft, 2: published
+            max_instances = 1,
+            mentors = ['robhoenig@gmail.com'],
+            tags = ['translation'], # free text
+            is_beginner = False,
+            # 1: Coding, 2: User Interface, 3: Documentation & Training,
+            # 4: Quality Assurance, 5: Outreach & Research
+            categories = [3, 5],
+            time_to_complete_in_days = 5, # must be between 3 and 7
+            # Field currently not accessible via API. gci-support says it is coming soon.
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/webhook-integrations.md",
+            private_metadata = "translations-A",
+            do_upload = args.force)
+
+    if 'B' in tasks:
+        upload_task(
+            # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+            name = '%s: Write general translation rules' % (language),
+            description = description_ABCD % {'type': 'B', 'language': language},
+            status = 2, # 1: draft, 2: published
+            max_instances = 1,
+            mentors = ['robhoenig@gmail.com'],
+            tags = ['translation'], # free text
+            is_beginner = False,
+            # 1: Coding, 2: User Interface, 3: Documentation & Training,
+            # 4: Quality Assurance, 5: Outreach & Research
+            categories = [3],
+            time_to_complete_in_days = 5, # must be between 3 and 7
+            # Field currently not accessible via API. gci-support says it is coming soon.
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/webhook-integrations.md",
+            private_metadata = "translations-B",
+            do_upload = args.force)
+
+    if 'C' in tasks:
+        upload_task(
+            # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+            name = '%s: Translate special terms used in Zulip' % (language),
+            description = description_ABCD % {'type': 'C', 'language': language},
+            status = 2, # 1: draft, 2: published
+            max_instances = 1,
+            mentors = ['robhoenig@gmail.com'],
+            tags = ['translation'], # free text
+            is_beginner = False,
+            # 1: Coding, 2: User Interface, 3: Documentation & Training,
+            # 4: Quality Assurance, 5: Outreach & Research
+            categories = [3],
+            time_to_complete_in_days = 5, # must be between 3 and 7
+            # Field currently not accessible via API. gci-support says it is coming soon.
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/webhook-integrations.md",
+            private_metadata = "translations-C",
+            do_upload = args.force)
+
+    if 'D' in tasks:
+        upload_task(
+            # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+            name = '%s: Improve style guide' % (language),
+            description = description_ABCD % {'type': 'D', 'language': language},
+            status = 2, # 1: draft, 2: published
+            max_instances = 1,
+            mentors = ['robhoenig@gmail.com'],
+            tags = ['translation'], # free text
+            is_beginner = False,
+            # 1: Coding, 2: User Interface, 3: Documentation & Training,
+            # 4: Quality Assurance, 5: Outreach & Research
+            categories = [3],
+            time_to_complete_in_days = 5, # must be between 3 and 7
+            # Field currently not accessible via API. gci-support says it is coming soon.
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/webhook-integrations.md",
+            private_metadata = "translations-D",
+            do_upload = args.force)
+
+# Task Type E
+upload_task(
+    # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+    name = 'Translations: Propose a language',
+    description = description_E,
+    status = 2, # 1: draft, 2: published
+    max_instances = 10,
+    mentors = ['robhoenig@gmail.com'],
+    tags = ['translation'], # free text
+    is_beginner = False,
+    # 1: Coding, 2: User Interface, 3: Documentation & Training,
+    # 4: Quality Assurance, 5: Outreach & Research
+    categories = [3],
+    time_to_complete_in_days = 5, # must be between 3 and 7
+    # Field currently not accessible via API. gci-support says it is coming soon.
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/webhook-integrations.md",
+    private_metadata = "translations-E",
+    do_upload = args.force)
+
+if not args.force:
+    print("No tasks uploaded. Add a -f argument to upload tasks to the GCI website.")
+    print("This is not idempotent. Running this twice with -f will create two sets of tasks.")

--- a/scripts/2017/upload.py
+++ b/scripts/2017/upload.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+task_uploader_path = os.path.abspath(os.path.join(__file__, '..', '..'))
+sys.path.append(task_uploader_path)
+from task_uploader.client import GCIAPIClient
+
+# Information about the fields is available at
+# https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+# One field is missing in the documentation and in the argument list below: external_url.
+# gci-support says it is coming soon.
+def upload_task(name, description, status, max_instances, mentors, tags, is_beginner,
+                categories, time_to_complete_in_days, private_metadata, do_upload = False):
+    task = locals()
+    del task['do_upload']
+    try:
+        homedir = os.path.expanduser("~")
+        with open(os.path.join(homedir, '.GCI_API_KEY')) as api_key_file:
+            API_KEY = api_key_file.readline().strip()
+    except IOError:
+        print("Please put your GCI API key at ~/.GCI_API_KEY.")
+        print("You can get your key from https://codein.withgoogle.com/dashboard/profile/.")
+        exit(1)
+
+    if do_upload:
+        GCIAPIClient(API_KEY).create_new_task(task)
+        print("Task created at https://codein.withgoogle.com/dashboard/tasks/")
+    else:
+        print("Dry run, printing task below.")
+        print(task)

--- a/scripts/task_uploader/client.py
+++ b/scripts/task_uploader/client.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import urlparse
+import urllib.parse
 
 import requests
 


### PR DESCRIPTION
I tested this with a dry run on Python 3 (don't know if it'll work on Python 2). Made a few mods to upload.py to update the path handling. 

For translations.py, I updated the script so we can set the individual task types we want for each language (for many languages, some have been completed from last years, others already have a style guide, etc.) 

I set myself as the mentor for translation tasks for now. @YagoGG feel free to add yourself once this is merged.