### PR TITLE
task scripts: Add linter-rules.py

### DIFF
--- a/scripts/2017/linter-rules.py
+++ b/scripts/2017/linter-rules.py
@@ -1,0 +1,44 @@
+import argparse
+from upload import upload_task
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--force', dest='force', action="store_true", default=False)
+args = parser.parse_args()
+
+description = """This task is about adding tests for Zulip's custom linter rules.
+
+Instructions for this task are at
+https://github.com/zulip/zulip-gci/blob/master/tasks/2017/linter-rules.md
+
+For this task, update the linter rule {}.
+"""
+
+linter_rules = [
+    ("groups trailing_whitespace_rule, whitespace_rules, markdown_whitespace_rules, markdown_rules, help_markdown_rules, and prose_style_rules", ['markdown']),
+    ("group js_rules", ['javascript']),
+    ("group python_rules", ['python']),
+    ("groups bash_rules, handlebars_rules and jinja2_rules", []),
+    ("groups css_rules and html_rules", ['html', 'css']),
+]
+
+for task, tags in linter_rules:
+    upload_task(
+        # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+        name = "Write tests for Zulip's code linter",
+        description = description.format(task),
+        status = 2, # 1: draft, 2: published
+        max_instances = 1,
+        mentors = ['robhoenig@gmail.com'],
+        tags = ['linting', 'testing'] + tags, # free text
+        is_beginner = True,
+        # 1: Coding, 2: User Interface, 3: Documentation & Training,
+        # 4: Quality Assurance, 5: Outreach & Research
+        categories = [1, 4],
+        time_to_complete_in_days = 3, # must be between 3 and 7
+        external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/linter-rules.md",
+        private_metadata = "linter-rules",
+        do_upload = args.force)
+
+if not args.force:
+    print("No tasks uploaded. Add a -f argument to upload tasks to the GCI website.")
+    print("This is not idempotent. Running this twice with -f will create two sets of tasks.")

--- a/tasks/2017/linter-rules.md
+++ b/tasks/2017/linter-rules.md
@@ -1,0 +1,23 @@
+# GCI Tasks: Linter rules
+
+## Prerequisites
+
+* A working Zulip development environment. See
+  [here](https://github.com/zulip/zulip-gci/blob/master/README.md) for
+  instructions on how to set one up.
+
+* You need to know how to create a GitHub pull request. Check out the
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/tasks/6541581402243072/)
+  task if you aren't sure how to do this, or read through the task
+  description [here](https://github.com/zulip/zulip-gci/blob/master/tasks/2017/submit-a-pull-request.md).
+
+* Update your working copy of Zulip and then create a feature branch. [Learn
+  how](../../before-every-task.md).
+
+## Task Description
+
+Linter rules are regexes that automatically check our codebase for errors.
+Your will write tests for a number of these rules. Specifically, your
+task is to work on [Zulip's Github issue #6662](https://github.com/zulip/zulip/issues/6662)
+for the rule groups specified in the task statement. Specific instructions are given in the
+issue description.


### PR DESCRIPTION
I updated the issue description of https://github.com/zulip/zulip/issues/6662 to be suitable for GCI students.

Fixes #634.