### PR TITLE
Add tasks for converting mypy annotations for multiline methods.

### DIFF
--- a/scripts/2017/mypy-annotations.py
+++ b/scripts/2017/mypy-annotations.py
@@ -1,0 +1,79 @@
+import argparse
+from upload import upload_task
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--force', dest='force', action="store_true", default=False)
+args = parser.parse_args()
+
+tasks_A = [
+    ["zerver/lib/test_runner.py", "zerver/views/zephyr.py", "zerver/webhooks/beanstalk/tests.py", "zerver/lib/upload.py"],
+    ["zerver/lib/soft_deactivation.py", "zerver/webhooks/papertrail/view.py", "zerver/webhooks/bitbucket2/view.py",
+     "zerver/webhooks/basecamp/view.py", "zerver/views/invite.py", "zerver/webhooks/jira/view.py",
+     "analytics/management/commands/populate_analytics_db.py", "analytics/tests/test_counts.py", "zerver/webhooks/teamcity/view.py"],
+    ["zerver/views/messages.py", "zerver/webhooks/semaphore/view.py"],
+    ["zerver/webhooks/travis/view.py", "zerver/lib/create_user.py", "zerver/webhooks/mention/view.py", "zerver/lib/events.py",
+     "zerver/webhooks/airbrake/view.py", "zerver/webhooks/yo/view.py", "zerver/webhooks/sentry/view.py"],
+    ["zilencer/views.py", "zerver/views/auth.py", "zerver/tests/test_home.py", "zerver/lib/webhooks/git.py", "zerver/lib/request.py"],
+    ["zerver/webhooks/zendesk/view.py", "zerver/webhooks/codeship/view.py", "zerver/webhooks/github_webhook/view.py",
+     "zerver/webhooks/deskdotcom/view.py", "zerver/webhooks/librato/view.py", "tools/lib/test_server.py", "scripts/lib/node_cache.py",
+     "zerver/webhooks/delighted/view.py", "zerver/models.py"],
+    ["zerver/webhooks/bitbucket2/tests.py", "zerver/tornado/event_queue.py", "zerver/tests/test_events.py"],
+    ["zerver/views/streams.py", "zerver/middleware.py"],
+    ["zerver/tests/test_decorators.py", "zerver/webhooks/slack/view.py", "zerver/webhooks/splunk/view.py", "zerver/lib/send_email.py",
+     "zerver/views/custom_profile_fields.py", "zerver/tests/test_messages.py", "zerver/webhooks/solano/view.py"],
+    ["zerver/webhooks/gogs/tests.py", "zerver/views/users.py", "zerver/webhooks/gitlab/view.py",
+     "zerver/management/commands/send_password_reset_email.py", "zerver/webhooks/bitbucket/tests.py"],
+    ["zerver/tests/test_management_commands.py", "zerver/views/email_mirror.py", "zerver/views/push_notifications.py",
+     "zerver/webhooks/gosquared/view.py", "zerver/lib/test_fixtures.py", "zerver/webhooks/taiga/view.py",
+     "analytics/views.py", "zerver/webhooks/helloworld/view.py", "zerver/views/alert_words.py"],
+    ["zerver/webhooks/appfollow/view.py", "zerver/webhooks/opsgenie/view.py", "zerver/webhooks/gogs/view.py",
+     "zerver/webhooks/ifttt/view.py", "zerver/tests/test_subdomains.py", "zerver/views/typing.py",
+     "zerver/webhooks/pingdom/view.py", "zerver/lib/avatar.py", "zerver/webhooks/greenhouse/view.py", "zerver/webhooks/beanstalk/view.py"],
+    ["zerver/forms.py", "zerver/webhooks/circleci/view.py", "zerver/webhooks/transifex/view.py",
+     "zerver/lib/export.py", "zerver/lib/integrations.py", "zerver/webhooks/bitbucket/view.py"],
+    ["zerver/webhooks/homeassistant/view.py", "zerver/webhooks/freshdesk/view.py", "zerver/lib/test_classes.py",
+     "tools/lister.py", "zerver/webhooks/newrelic/view.py"],
+    ["zerver/decorator.py", "zerver/views/pointer.py", "zerver/tests/test_auth_backends.py"],
+    ["zerver/views/user_settings.py", "zerver/webhooks/stripe/view.py", "zerver/webhooks/gitlab/tests.py",
+     "zerver/webhooks/crashlytics/view.py", "zerver/webhooks/wordpress/view.py"],
+    ["zerver/webhooks/trello/tests.py", "zerver/tests/test_docs.py", "zerver/views/realm_filters.py",
+     "zerver/tests/test_subs.py", "zerver/tornado/websocket_client.py", "zerver/tests/test_user_groups.py"],
+    ["analytics/lib/fixtures.py", "zerver/views/tutorial.py", "zerver/lib/bugdown/__init__.py", "zproject/backends.py",
+     "zerver/webhooks/heroku/view.py", "zerver/webhooks/gci/view.py", "zerver/webhooks/zapier/view.py", "zerver/views/realm.py"]
+]
+
+description_A = """Help convert mypy annotations for multiline methods in the Zulip codebase!
+This is a great way to practice git, git grep, and efficiently using a powerful editor.
+
+Instructions for mypy annotation task are at
+https://github.com/zulip/zulip-gci/blob/master/tasks/2017/mypy-annotations.md.
+
+For this task, do **Task Type A** for the following set of files:
+
+%s
+"""
+
+for files in tasks_A:
+    file_list = "\n".join([("* " + file_name) for file_name in files]),
+    upload_task(
+        # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
+        name = 'Update mypy annotations to Python 3 syntax',
+        description = description_A % file_list,
+        status = 2, # 1: draft, 2: published
+        max_instances = 1,
+        mentors = ['rishig@zulipchat.com', 'tabbott@zulipchat.com'],
+        tags = ['python', 'mypy'], # free text
+        is_beginner = False,
+        # 1: Coding, 2: User Interface, 3: Documentation & Training,
+        # 4: Quality Assurance, 5: Outreach & Research
+        categories = [1],
+        time_to_complete_in_days = 3, # must be between 3 and 7
+        # Field currently not accessible via API. gci-support says it is coming soon.
+        # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/mypy-annotations.md",
+        private_metadata = "mypy-annotations-A",
+        do_upload = args.force)
+
+if not args.force:
+    print
+    print("No tasks uploaded. Add a -f argument to upload tasks to the GCI website.")
+    print("This is not idempotent. Running this twice with -f will create two sets of tasks.")

--- a/tasks/2017/mypy-annotations.md
+++ b/tasks/2017/mypy-annotations.md
@@ -1,0 +1,60 @@
+# GCI Tasks: Mypy Annotations
+
+## Prerequisites
+
+* A working Zulip development environment. See
+  [here](https://github.com/zulip/zulip-gci/blob/master/README.md) for instructions
+  on how to set one up.
+
+* Update your working copy of Zulip and then create a feature branch. [Learn
+  how](../../before-every-task.md).
+
+* If this is your first contribution, you may be interested in the
+  [how to create a pull request](https://codein.withgoogle.com/tasks/6541581402243072/) and
+  [intro to Zulip server development](https://codein.withgoogle.com/tasks/4799263762546688/) tasks.
+
+## Background
+
+Mypy is an experimental static type checker for Python. Mypy ensures that
+the codebase doesn't do things like pass a string (like `'42'`) to a function
+that is expecting an int (like `42`).
+
+You can read more about how mypy works at
+http://zulip.readthedocs.io/en/latest/mypy.html.
+
+Zulip has reached 100% mypy annotations coverage as a result of
+work done during last year's code-in. Earlier, comments were used
+to specify types to support both Python 2 and 3. As we're migrating our
+codebase to Python 3 only, we can use the new PEP484 syntax for
+type annotations.
+
+Although we've built an automated script to convert most of these annotations, we
+still need to convert methods with multiline definitions manually.
+
+## Task Descriptions
+
+### Task Type A
+
+Let *file* be a file listed in the task that brought you here.
+* Convert mypy annotations for all multiline methods in the *file*.
+* Commit your changes with a commit message `mypy: User Python 3 syntax for typing in <file>.`
+
+After you've converted the annotations for all the files, Submit a pull request,
+with title  `mypy: Use Python 3 syntax for typing in <file>.`
+  Include a link to the pull request when you submit your task on the GCI website.
+
+*Completion criteria*:
+* PASS_TRAVIS
+* Mentor review. Mentors will review the code changes.
+* Mentors should also make sure that the modified method definitions
+are line-wrapped properly and readable
+
+http://zulip.readthedocs.io/en/latest/mypy.html is a helpful document, as is
+just looking at other files in the project and seeing their annotations.
+
+## General notes
+
+`tools/test-all` runs most of the tests in Travis, but is somewhat slow.
+`tools/run-mypy` runs just the mypy tests. You can also run
+`tools/run-mypy file` on a particular file or directory, which is even faster,
+but may not catch all the mistakes in that file.


### PR DESCRIPTION
Used this script (https://gist.github.com/sampritipanda/b8b119fe758d9548233ef7be1624bd07) to find out all the methods and then randomly shuffled the files into seperate tasks. Please check the language :)

There are about 10 methods to fix per task.

Fixes #616 