### PR TITLE
scripts: Expand the list of webhook integrations to write.

### DIFF
--- a/scripts/2017/webhook-integrations.py
+++ b/scripts/2017/webhook-integrations.py
@@ -7,6 +7,13 @@ args = parser.parse_args()
 
 integrations = [
 #  These are new integrations for GCI 2017.
+    ('Rollbar', 'provides real-time error alerting and debugging tools for developers'),
+    ('StatusPage.io', 'notifies teams when a status page of their app or website has changed'),
+    ('Runscope', 'alerts teams when their APIs are broken or slow'),
+    ('Honeybadger', 'provides exception and uptime monitoring for Ruby apps'),
+    ('Raygun', 'an error and performance monitoring tool for web and mobile apps'),
+    ('Opbeat', 'a performance monitoring tool for JavaScript developers'),
+    ('Insping', 'monitors websites for downtime and alerts teams when websites go down'),
     #  ('Mailchimp', 'an email marketing tool'),  # Hubot integration exists in main repo
     # ('Zeplin', 'design collaboration')  # couldn't find public API
     # ('InVision', 'a collaborative prototyping app'),  # no API yet: https://support.invisionapp.com/hc/en-us/articles/203730795-Does-InVision-have-an-API-for-integration


### PR DESCRIPTION
Added several integrations that are relatively easy to grasp and support custom webhook notifications. I have a couple more in mind, and I can add them quickly if we run out.