### PR TITLE
scripts/2017: remove external_url when duplicating description

### DIFF
--- a/scripts/2017/git-comfortable.py
+++ b/scripts/2017/git-comfortable.py
@@ -24,7 +24,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [1, 3],
     time_to_complete_in_days = 5, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/git-comfortable.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/git-comfortable.md",
     private_metadata = "git-comfortable",
     do_upload = args.force)
 

--- a/scripts/2017/intro-to-zulip-mobile.py
+++ b/scripts/2017/intro-to-zulip-mobile.py
@@ -25,7 +25,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [1, 3],
     time_to_complete_in_days = 5, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/intro-to-zulip-mobile.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/intro-to-zulip-mobile.md",
     private_metadata = "intro-to-zulip-mobile",
     do_upload = args.force)
 

--- a/scripts/2017/intro-to-zulip-server.py
+++ b/scripts/2017/intro-to-zulip-server.py
@@ -28,7 +28,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [1, 3],
     time_to_complete_in_days = 5, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/intro-to-zulip-server.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/intro-to-zulip-server.md",
     private_metadata = "intro-to-zulip-server",
     do_upload = args.force)
 
@@ -46,7 +46,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [1, 3],
     time_to_complete_in_days = 5, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/intro-to-zulip-server.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/intro-to-zulip-server.md",
     private_metadata = "intro-to-zulip-server",
     do_upload = args.force)
 

--- a/scripts/2017/linter-rules.py
+++ b/scripts/2017/linter-rules.py
@@ -37,7 +37,7 @@ for task, tags in linter_rules:
         # 4: Quality Assurance, 5: Outreach & Research
         categories = [1, 4],
         time_to_complete_in_days = 3, # must be between 3 and 7
-        external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/linter-rules.md",
+        # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/linter-rules.md",
         private_metadata = "linter-rules",
         do_upload = args.force)
 

--- a/scripts/2017/mypy-annotations.py
+++ b/scripts/2017/mypy-annotations.py
@@ -70,8 +70,7 @@ for files in tasks_A:
         # 4: Quality Assurance, 5: Outreach & Research
         categories = [1],
         time_to_complete_in_days = 4, # must be between 3 and 7
-        # Field currently not accessible via API. gci-support says it is coming soon.
-        external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/mypy-annotations.md",
+        # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/mypy-annotations.md",
         private_metadata = "mypy-annotations-A",
         do_upload = args.force)
 

--- a/scripts/2017/node-coverage.py
+++ b/scripts/2017/node-coverage.py
@@ -5,7 +5,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--force', dest='force', action="store_true", default=False)
 args = parser.parse_args()
 
-files = [
+files_uploaded = [
     ('narrow_state.js', ['exports.operators', 'collect_single', 'exports.set_compose_defaults', 'exports.stream', 'exports.topic', 'exports.is_for_stream_id']),
     ('stream_data.js',  ['exports.delete_sub', 'exports.invite_streams', 'exports.get_subscriber_count', 'exports.render_stream_description',
                          'exports.canonicalized_name', 'exports.name_in_home_view', 'exports.notifications_in_home_view', 'exports.get_default_status',
@@ -13,6 +13,8 @@ files = [
                          'exports.receives_audible_notifications', 'exports.initialize_from_page_params', 'exports.get_newbie_stream', 'exports.remove_default_stream']),
     ('user_groups.js',  ['exports.get_user_group_from_id', 'exports.get_user_group_from_name', 'exports.initialize'])
 ]
+
+files = []
 
 description = """Unit tests ensure the quality and correctness of your code, especially when doing
 large code refactorings, and prevent regressions. Zulip uses node to unit test its
@@ -47,7 +49,7 @@ for file, functions in files:
         # 4: Quality Assurance, 5: Outreach & Research
         categories = [1],
         time_to_complete_in_days = 5, # must be between 3 and 7
-        external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/node-coverage.md",
+        # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/node-coverage.md",
         private_metadata = "node-coverage",
         do_upload = args.force)
 

--- a/scripts/2017/quality-assurance.py
+++ b/scripts/2017/quality-assurance.py
@@ -25,7 +25,7 @@ upload_task(
     categories = [2, 4],
     time_to_complete_in_days = 3, # must be between 3 and 7
     # Field currently not accessible via API. gci-support says it is coming soon.
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/quality-assurance.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/quality-assurance.md",
     private_metadata = "quality-assurance",
     do_upload = args.force)
 

--- a/scripts/2017/spread-the-word.py
+++ b/scripts/2017/spread-the-word.py
@@ -27,7 +27,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [5],
     time_to_complete_in_days = 3, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/spread-the-word.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/spread-the-word.md",
     private_metadata = "spread-the-word",
     do_upload = args.force)
 

--- a/scripts/2017/submit-a-pull-request.py
+++ b/scripts/2017/submit-a-pull-request.py
@@ -24,7 +24,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [3],
     time_to_complete_in_days = 5, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/submit-a-pull-request.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/submit-a-pull-request.md",
     private_metadata = "submit-a-pull-request",
     do_upload = args.force)
 

--- a/scripts/2017/translations.py
+++ b/scripts/2017/translations.py
@@ -7,7 +7,9 @@ args = parser.parse_args()
 
 # Add customized task for Japanese and Korean, as these are mostly fully translated,
 # but have no style guides.
-languages_tasks = [
+languages_tasks = []
+
+languages_tasks_uploaded = [
     ('Arabic', ['A', 'B',]),
     ('French', ['D',]),
     ('Hungarian', ['A', 'B', 'C',]),
@@ -56,7 +58,7 @@ for language_tasks in languages_tasks:
             # 4: Quality Assurance, 5: Outreach & Research
             categories = [3, 5],
             time_to_complete_in_days = 5, # must be between 3 and 7
-            external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
             private_metadata = "translations-A",
             do_upload = args.force)
 
@@ -74,7 +76,7 @@ for language_tasks in languages_tasks:
             # 4: Quality Assurance, 5: Outreach & Research
             categories = [3],
             time_to_complete_in_days = 5, # must be between 3 and 7
-            external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
             private_metadata = "translations-B",
             do_upload = args.force)
 
@@ -92,7 +94,7 @@ for language_tasks in languages_tasks:
             # 4: Quality Assurance, 5: Outreach & Research
             categories = [3],
             time_to_complete_in_days = 5, # must be between 3 and 7
-            external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
             private_metadata = "translations-C",
             do_upload = args.force)
 
@@ -110,7 +112,7 @@ for language_tasks in languages_tasks:
             # 4: Quality Assurance, 5: Outreach & Research
             categories = [3],
             time_to_complete_in_days = 5, # must be between 3 and 7
-            external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
+            # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
             private_metadata = "translations-D",
             do_upload = args.force)
 
@@ -128,7 +130,7 @@ upload_task(
     # 4: Quality Assurance, 5: Outreach & Research
     categories = [3],
     time_to_complete_in_days = 5, # must be between 3 and 7
-    external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
+    # external_url = "https://github.com/zulip/zulip-gci/blob/master/tasks/2017/translations.md",
     private_metadata = "translations-E",
     do_upload = args.force)
 

--- a/scripts/2017/upload.py
+++ b/scripts/2017/upload.py
@@ -7,12 +7,11 @@ from task_uploader.client import GCIAPIClient
 
 # Information about the fields is available at
 # https://developers.google.com/open-source/gci/resources/downloads/TaskAPISpec.pdf
-# One field is missing in the documentation and in the argument list below: external_url.
-# gci-support says it is coming soon.
 def upload_task(*, name, description, status, max_instances, mentors, tags, is_beginner,
-                categories, time_to_complete_in_days, private_metadata, external_url=None, do_upload = False):
+                categories, time_to_complete_in_days, private_metadata, external_url = None, do_upload = False):
     task = locals()
     del task['do_upload']
+    # external_url is an optional field. If it's not there, then we shouldn't pass the empty value.
     if task['external_url'] is None:
         del task['external_url']
     try:

--- a/scripts/2017/upload.py
+++ b/scripts/2017/upload.py
@@ -10,9 +10,11 @@ from task_uploader.client import GCIAPIClient
 # One field is missing in the documentation and in the argument list below: external_url.
 # gci-support says it is coming soon.
 def upload_task(*, name, description, status, max_instances, mentors, tags, is_beginner,
-                categories, time_to_complete_in_days, private_metadata, external_url, do_upload = False):
+                categories, time_to_complete_in_days, private_metadata, external_url=None, do_upload = False):
     task = locals()
     del task['do_upload']
+    if task['external_url'] is None:
+        del task['external_url']
     try:
         homedir = os.path.expanduser("~")
         with open(os.path.join(homedir, '.GCI_API_KEY')) as api_key_file:


### PR DESCRIPTION
The external_url display makes it look like it is part of
the description, and therefore duplicating the url in the
description, if present.

Also, moves some uploaded tasks to an "uploaded" list. 