### PR TITLE
Update task links to point to 2017 GCI tasks.

### DIFF
--- a/tasks/2017/interactive-bots.md
+++ b/tasks/2017/interactive-bots.md
@@ -7,7 +7,7 @@
   instructions on how to set one up.
 
 * You need to know how to create a GitHub pull request. Check out the
-  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/tasks/6541581402243072/)(TODO: Need to update this link with the new one)
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/dashboard/tasks/4884433561714688/)
   task if you aren't sure how to do this, or read through the task
   description [here](https://github.com/zulip/zulip-gci/tree/master/submit-a-pull-request).
 

--- a/tasks/2017/linter-rules.md
+++ b/tasks/2017/linter-rules.md
@@ -7,7 +7,7 @@
   instructions on how to set one up.
 
 * You need to know how to create a GitHub pull request. Check out the
-  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/tasks/6541581402243072/)
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/dashboard/tasks/4884433561714688/)
   task if you aren't sure how to do this, or read through the task
   description [here](https://github.com/zulip/zulip-gci/blob/master/tasks/2017/submit-a-pull-request.md).
 

--- a/tasks/2017/mypy-annotations.md
+++ b/tasks/2017/mypy-annotations.md
@@ -10,8 +10,8 @@
   how](../../before-every-task.md).
 
 * If this is your first contribution, you may be interested in the
-  [how to create a pull request](https://codein.withgoogle.com/tasks/6541581402243072/) and
-  [intro to Zulip server development](https://codein.withgoogle.com/tasks/4799263762546688/) tasks.
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/dashboard/tasks/4884433561714688/) and
+  [intro to Zulip server development](https://codein.withgoogle.com/dashboard/tasks/5165908538425344/) tasks.
 
 ## Background
 

--- a/tasks/2017/submit-a-pull-request.md
+++ b/tasks/2017/submit-a-pull-request.md
@@ -67,4 +67,4 @@ GitHub: https://zulip.readthedocs.io/en/latest/git/index.html.
 
 After you finish this task, a great next task is to learn how to use
 the Zulip server development environment:
-https://codein.withgoogle.com/tasks/4799263762546688/
+https://codein.withgoogle.com/dashboard/tasks/5165908538425344/

--- a/tasks/2017/translations.md
+++ b/tasks/2017/translations.md
@@ -10,7 +10,7 @@
   how](../../before-every-task.md).
 
 * You need to know how to create a GitHub pull request. Check out the
-  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/tasks/6541581402243072/)
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/dashboard/tasks/4884433561714688/)
   task if you aren't sure how to do this, or read through the task description
   [here](submit-a-pull-request.md).
 

--- a/tasks/2017/visual-art.md
+++ b/tasks/2017/visual-art.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 * You need to know how to create a GitHub pull request. Check out the
-  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/tasks/6541581402243072/)(TODO: Need to update this link with the new one)
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/dashboard/tasks/4884433561714688/)
   task if you aren't sure how to do this, or read through the task
   description [here](https://github.com/zulip/zulip-gci/tree/master/submit-a-pull-request).
 

--- a/tasks/2017/webhook-integrations.md
+++ b/tasks/2017/webhook-integrations.md
@@ -10,8 +10,8 @@
   how](../../before-every-task.md).
 
 * If this is your first contribution, you may be interested in the
-  [how to create a pull request](https://codein.withgoogle.com/tasks/6541581402243072/) and
-  [intro to Zulip server development](https://codein.withgoogle.com/tasks/4799263762546688/) tasks.
+  [Learn how to create a GitHub Pull Request](https://codein.withgoogle.com/dashboard/tasks/4884433561714688/) and
+  [intro to Zulip server development](https://codein.withgoogle.com/dashboard/tasks/5165908538425344/) tasks.
 
 ## Background
 


### PR DESCRIPTION
Without the `dashboard`, links don't work yet. I assume that the additional `dashboard` won't make a differene for students once the contest has started.